### PR TITLE
bug fix: Change number of digits in vtk output sequence

### DIFF
--- a/pyathena/load_sim.py
+++ b/pyathena/load_sim.py
@@ -298,8 +298,8 @@ class LoadSim(object):
                 self.nums = None
                 self.nums_id0 = None
             else:
-                self.nums = [int(f[-7:-4]) for f in self.files['vtk']]
-                self.nums_id0 = [int(f[-7:-4]) for f in self.files['vtk_id0']]
+                self.nums = [int(f[-8:-4]) for f in self.files['vtk']]
+                self.nums_id0 = [int(f[-8:-4]) for f in self.files['vtk_id0']]
                 if self.nums_id0:
                     self.logger.info('vtk in id0: {0:s} nums: {1:d}-{2:d}'.format(
                         osp.dirname(self.files['vtk_id0'][0]),


### PR DESCRIPTION
Description:
Athena vtk outputs are numbered as four-digits (e.g., gc.0020.vtk),
but current code reads only three trailing digits (e.g., 020 in gc.0020.vtk).
This works fine for num=0, 1, ..., 999, but not for num > 1000.