### PR TITLE
Make pyathena compaitible with yt-4.0

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -1,4 +1,4 @@
-name: pyathena
+name: pyathena-yt4
 channels:
   - conda-forge
 dependencies:
@@ -7,12 +7,14 @@ dependencies:
   - numpy
   - astropy
   - pandas
-  - yt
+  - yt=4.0
   - healpy
   - xarray
   - netCDF4
   - jupyter
   - cmasher
   - cmocean
+  - tqdm
+  - pip=21.2.4
   - pip:
-    - tqdm
+    - periodictable

--- a/pyathena/fields/xray_emissivity.py
+++ b/pyathena/fields/xray_emissivity.py
@@ -10,7 +10,6 @@ from yt.fields.derived_field import DerivedField
 from yt.funcs import \
     mylog, \
     only_on_root, \
-    issue_deprecation_warning, \
     parse_h5_attr
 from yt.utilities.exceptions import YTFieldNotFound
 from yt.utilities.exceptions import YTException
@@ -64,9 +63,9 @@ class XrayEmissivityIntegrator(object):
     table_type : string
         The type of data to use when computing the emissivity values. If "cloudy",
         a file called "cloudy_emissivity.h5" is used, for photoionized
-        plasmas. If, "apec", a file called "apec_emissivity.h5" is used for 
-        collisionally ionized plasmas. These files contain emissivity tables 
-        for primordial elements and for metals at solar metallicity for the 
+        plasmas. If, "apec", a file called "apec_emissivity.h5" is used for
+        collisionally ionized plasmas. These files contain emissivity tables
+        for primordial elements and for metals at solar metallicity for the
         energy range 0.1 to 100 keV.
     redshift : float, optional
         The cosmological redshift of the source of the field. Default: 0.0.
@@ -141,7 +140,7 @@ def get_xray_emissivity(T, Z=1.0, emin=0.5, emax=7.0, table_type='apec', energy=
     x = XrayEmissivityIntegrator(table_type, data_dir=data_dir)
     log_em_0 = x.get_interpolator('primordial', emin, emax, energy=energy)
     log_em_z = x.get_interpolator('metals', emin, emax, energy=energy)
-    
+
     dd = dict(log_nH=0.0, log_T=np.log10(T))
     em_tot = 10.0**log_em_0(dd) + Z*10.0**log_em_z(dd)
     return em_tot

--- a/setup_stellar.sh
+++ b/setup_stellar.sh
@@ -9,9 +9,9 @@ module load anaconda3/2020.11
 
 # create an environment
 
-conda env create -f pyathena_env.yml
+conda env create -f env.yml
 
-conda activate pyathena
+conda activate pyathena-yt4
 
 # installing mpi4py on stellar
 # https://researchcomputing.princeton.edu/support/knowledge-base/mpi4py


### PR DESCRIPTION
* do not import a removed function `issue_deprecation_warning` from `yt.funcs`
* correct env file name in the `stellar-setup.sh` script
* make `yt-4.0` default in `env.yml`
* add the `pip: periodictable` dependency in `env.yml` 