### PR TITLE
Read tar output

### DIFF
--- a/pyathena/io/read_vtk.py
+++ b/pyathena/io/read_vtk.py
@@ -396,7 +396,10 @@ class AthenaDataSet(object):
             return grid['data'][field]
         elif field in self.field_list:
             fm = grid['field_map'][field]
-            fp = open(grid['filename'], 'rb')
+            if 'tarinfo' in grid:
+                fp = self.tarfile.extractfile(grid['tarinfo'])
+            else:
+                fp = open(grid['filename'], 'rb')
             fp.seek(fm['offset'])
             fp.readline() # skip header
             if fm['read_table']:
@@ -467,14 +470,16 @@ class AthenaDataSet(object):
         domain['Nx'] = np.round(domain['Lx']/domain['dx']).astype('int')
         domain['ndim'] = 3 # always 3d
 
-        file = open(self.fnames[0], 'rb')
-        tmpgrid = dict()
-        tmpgrid['time'] = None
-        while tmpgrid['time'] is None:
-            line = file.readline()
-            _vtk_parse_line(line, tmpgrid)
-        file.close()
-        domain['time'] = tmpgrid['time']
+        # file = open(self.fnames[0], 'rb')
+        # tmpgrid = dict()
+        # tmpgrid['time'] = None
+        # while tmpgrid['time'] is None:
+        #     line = file.readline()
+        #     _vtk_parse_line(line, tmpgrid)
+        # file.close()
+        # domain['time'] = tmpgrid['time']
+
+        domain['time'] = grid[0]['time']
 
         return domain
 

--- a/pyathena/io/read_vtk_tar.py
+++ b/pyathena/io/read_vtk_tar.py
@@ -1,0 +1,191 @@
+"""
+Read athena tarred vtk file
+"""
+
+from __future__ import print_function
+
+import os
+import os.path as osp
+import glob, struct
+import numpy as np
+import xarray as xr
+import astropy.constants as ac
+import astropy.units as au
+import tarfile
+from .read_vtk import AthenaDataSet,_parse_filename,_vtk_parse_line
+
+from ..util.units import Units
+
+def read_vtk_tar(filename, id0_only=False):
+    """Convenience wrapper function to read Athena vtk output file
+    using AthenaDataSet class.
+
+    Parameters
+    ----------
+    filename : string
+        Name of the file to open, including extension
+    id0_only : bool
+        Flag to enforce to read vtk file in id0 directory only.
+        Default value is False.
+
+    Returns
+    -------
+    ds : AthenaDataSet
+    """
+
+    return AthenaDataSetTar(filename, id0_only=id0_only)
+
+class AthenaDataSetTar(AthenaDataSet):
+
+    def __init__(self, filename, id0_only=False, units=Units(), dfi=None):
+        """Class to read athena vtk file.
+
+        Parameters
+        ----------
+        filename : string
+            Name of the file to open, including extension
+        id0_only : bool
+            Flag to enforce to read vtk file in id0 directory only.
+            Default value is False.
+        units : Units
+            pyathena Units object (used for reading derived fields)
+        dfi : dict
+            Dictionary containing derived fields info
+        """
+
+        if not osp.exists(filename):
+            raise IOError(('File does not exist: {0:s}'.format(filename)))
+
+        dirname, problem_id, num, suffix, ext, mpi_mode, nonzero_id = \
+            _parse_filename(filename)
+
+        if id0_only:
+            mpi_mode = False
+
+        self.dirname = dirname
+        self.problem_id = problem_id
+        self.num = int(num)
+        self.suffix = suffix
+        self.ext = ext
+        self.mpi_mode = mpi_mode
+        self.fnames = [filename]
+        self.u = units
+        self.dfi = dfi
+        if dfi is not None:
+            self.derived_field_list = list(dfi.keys())
+        else:
+            self.derived_field_list = None
+
+        # open tar file
+        if ext == 'tar':
+            self.tarfile = tarfile.open(filename)
+            self.fnames = self.tarfile.getnames()[1:]
+            self.mpi_mode = len(self.fnames)>1
+        else:
+            raise IOError(('[read_vtk_tar] Expected tarred file but provided:'
+                           ' {0:s}'.format(filename)))
+        self.grid = self._set_grid()
+        self.domain = self._set_domain()
+        self.set_region()
+
+        # Need separte field_map for different grids
+        if self.domain['all_grid_equal']:
+            self._field_map = _set_field_map(self.grid[0],self.tarfile)
+            for g in self.grid:
+                g['field_map'] = self._field_map
+        else:
+            for g in self.grid:
+                g['field_map'] = _set_field_map(g,self.tarfile)
+            self._field_map = self.grid[0]['field_map']
+
+        self.field_list = list(self._field_map.keys())
+
+    def _set_grid(self):
+        grid = []
+        members = self.tarfile.getmembers()
+        # Record filename and data_offset
+        for i, tarinfo in enumerate(members):
+            if tarinfo.isdir(): continue
+            file = self.tarfile.extractfile(tarinfo)
+            g = dict()
+            g['data'] = dict()
+            g['filename'] = tarinfo.name[5:]
+            g['tarinfo'] = tarinfo
+            g['read_field'] = None
+            g['read_type'] = None
+
+            while g['read_field'] is None:
+                g['data_offset'] = file.tell()
+                line = file.readline()
+                _vtk_parse_line(line, g)
+            file.close()
+            g['Nx'] -= 1
+            g['Nx'][g['Nx'] == 0] = 1
+            g['dx'][g['Nx'] == 1] = 1.0
+
+            # Right edge
+            g['re'] = g['le'] + g['Nx']*g['dx']
+            grid.append(g)
+        ranklist=[]
+        for g in grid:
+            fname = g['filename']
+            if '-id' in fname: rank = int(fname.split('-id')[1].split('.')[0])
+            else: rank = 0
+            ranklist.append(rank)
+        return list(np.array(grid)[np.argsort(ranklist)])
+
+
+def _set_field_map(grid,tf):
+    fp = tf.extractfile(grid['tarinfo'])
+
+    fp.seek(0, 2)
+    eof = fp.tell()
+    offset = grid['data_offset']
+    fp.seek(offset)
+
+    field_map = dict()
+    if 'Nx' in grid:
+        Nx = grid['Nx']
+
+    while offset < eof:
+        line = fp.readline()
+        sp = line.strip().split()
+        field = sp[1].decode('utf-8')
+        field_map[field] = dict()
+        field_map[field]['read_table'] = False
+        if b"SCALARS" in line:
+            tmp = fp.readline()
+            field_map[field]['read_table'] = True
+            field_map[field]['nvar'] = 1
+        elif b"VECTORS" in line:
+            field_map[field]['nvar'] = 3
+        else:
+            raise TypeError(sp[0] + ' is unknown type.')
+
+        field_map[field]['offset'] = offset
+        field_map[field]['ndata'] = field_map[field]['nvar']*grid['ncells']
+        if field == 'face_centered_B1':
+            field_map[field]['ndata'] = (Nx[0]+1)*Nx[1]*Nx[2]
+        elif field == 'face_centered_B2':
+            field_map[field]['ndata'] = Nx[0]*(Nx[1]+1)*Nx[2]
+        elif field == 'face_centered_B3':
+            field_map[field]['ndata'] = Nx[0]*Nx[1]*(Nx[2]+1)
+
+        if sp[2] == b'int':
+            dtype = 'i'
+        elif sp[2] == b'float':
+            dtype = 'f'
+        elif sp[2] == b'double':
+            dtype = 'd'
+
+        field_map[field]['dtype'] = dtype
+        field_map[field]['dsize'] = field_map[field]['ndata']*struct.calcsize(dtype)
+        fp.seek(field_map[field]['dsize'], 1)
+        offset = fp.tell()
+        tmp = fp.readline()
+        if len(tmp) > 1:
+            fp.seek(offset)
+        else:
+            offset = fp.tell()
+
+    return field_map

--- a/pyathena/load_sim.py
+++ b/pyathena/load_sim.py
@@ -281,6 +281,10 @@ class LoadSim(object):
                  osp.basename(self.frst), self.rh.time))
 
         return self.rh
+    def create_vtk_tar_all(self,remove_original=False):
+        raw_tardirs = self._find_match([("vtk","????")])
+        for num in [int(f[-4:]) for f in raw_tardir]:
+            self.creat_vtk_tar(num=num, remove_original=remove_original)
 
     def create_vtk_tar(self, num=None, remove_original=False, move=True):
         """Creating tarred vtk from rearranged vtk output

--- a/pyathena/load_sim.py
+++ b/pyathena/load_sim.py
@@ -13,6 +13,8 @@ import pandas as pd
 import xarray as xr
 import pickle
 import yt
+import tarfile
+import shutil
 
 from .classic.vtk_reader import AthenaDataSet as AthenaDataSetClassic
 from .io.read_vtk import AthenaDataSet
@@ -279,6 +281,73 @@ class LoadSim(object):
                  osp.basename(self.frst), self.rh.time))
 
         return self.rh
+
+    def create_vtk_tar(self, num=None, remove_original=False, move=True):
+        """Creating tarred vtk from rearranged vtk output
+        or automatically move vtk files under id* to the rearranged vtk folders
+
+        Parameters
+        ----------
+        num : int
+           Snapshot number, e.g., /basedir/vtk/xxxx
+        remove_original : bool
+           Remove original after tar it if True
+        move : bool
+           Move vtk files under id* to /basedir/vtk/xxxx to tar it
+        """
+        # set tar file name
+        dirname = osp.join(self.basedir,'vtk')
+        fpattern = '{0:s}.{1:04d}.tar'
+        tarname = osp.join(dirname, fpattern.format(self.problem_id, num))
+        tardir = os.path.join(dirname,'{0:04d}'.format(num))
+
+        # remove originals
+        def remove_tardir():
+            if osp.isdir(tardir) and remove_original:
+                self.logger_info('[create_vtk_tar] removing originals'
+                                 ' at {}'.format(tardir))
+                try:
+                    shutil.rmtree(tardir)
+                except OSError as e:
+                    print ("Error: %s - %s." % (e.filename, e.strerror))
+
+        # check file existence then move
+        # move files to vtk/num/*.num.tar
+        if osp.isfile(tarname):
+            # if tar file exists, remove original and quit
+            self.logger.info('[create_vtk_tar] tar file already exists')
+            remove_tardir()
+            return
+
+        if not osp.isdir(tardir):
+            self.logger.info('[create_vtk_tar] vtk files are not located'
+                             ' in a separate folder.')
+            # move files under id* to vtk/num
+            if (move):
+                # create folder
+                self.logger.info('[create_vtk_tar] create a folder {:s}'.format(tardir))
+                os.makedirs(tardir)
+                # find files
+                id_files = [self._get_fvtk('vtk_id0',num=num)]
+                id_files += self._find_match([('id*','{0:s}-id*.{1:04d}.{2:s}'.\
+                                              format(self.problem_id, num, 'vtk'))])
+                # move each file
+                self.logger.info('[create_vtk_tar] moving {:d} files to {:s}'.\
+                                 format(len(id_files),tardir))
+                for f in id_files: shutil.move(f,tardir)
+            else:
+                # if tardir doesn't exist, move files under id* or just quit
+                return
+
+        # tar to vtk/problem_id.num.tar
+        self.logger.info('[create_vtk_tar] tarring vtk files')
+
+        tf = tarfile.open(tarname,'x')
+        tf.add(tardir)
+        tf.close()
+
+        # remove_original
+        remove_tardir()
 
     def print_all_properties(self):
         """Print all attributes and callable methods

--- a/pyathena/load_sim.py
+++ b/pyathena/load_sim.py
@@ -281,13 +281,15 @@ class LoadSim(object):
                  osp.basename(self.frst), self.rh.time))
 
         return self.rh
-    def create_vtk_tar_all(self,remove_original=False):
-        raw_tardirs = self._find_match([("vtk","????")])
-        for num in [int(f[-4:]) for f in raw_tardir]:
-            self.move_to_tardir(num=num)
-            self.creat_vtk_tar(num=num, remove_original=remove_original)
 
-    def move_to_tardir(self, num=None):
+    def create_vtk_tar_all(self,remove_original=False):
+        for num in self.nums_id0:
+            self.move_to_tardir(num=num)
+        raw_tardirs = self._find_match([("vtk","????")])
+        for num in [int(f[-4:]) for f in raw_tardirs]:
+            self.create_vtk_tar(num=num, remove_original=remove_original)
+
+    def move_to_tardir(self, num=None, kind='vtk'):
         """Move vtk files from id* to vtk/XXXX
 
         Parameters
@@ -297,32 +299,34 @@ class LoadSim(object):
 
         """
         # set tar file name
-        dirname = osp.join(self.basedir,'vtk')
+        dirname = osp.join(self.basedir,kind)
         fpattern = '{0:s}.{1:04d}.tar'
         tarname = osp.join(dirname, fpattern.format(self.problem_id, num))
         tardir = os.path.join(dirname,'{0:04d}'.format(num))
 
         # move files to vtk/num/*.num.tar
         if osp.isdir(tardir):
-            self.logger.info('[move_to_tardir] vtk/{:04d} exists'.format(num))
+            self.logger.info('[move_to_tardir] {:s} exists'.format(tardir))
             return
 
         # move files under id* to vtk/num
         # create folder
-        self.logger.info('[create_vtk_tar] create a folder {:s}'.format(tardir))
+        # self.logger.info('[create_vtk_tar] create a folder {:s}'.format(tardir))
         os.makedirs(tardir)
         # find files
-        id_files = [self._get_fvtk('vtk_id0',num=num)]
+        if kind == 'vtk':
+            id_files = [self._get_fvtk('vtk_id0',num=num)]
+        elif kind == 'rst':
+            id_files = [self._get_fvtk('rst',num=num)]
         id_files += self._find_match([('id*','{0:s}-id*.{1:04d}.{2:s}'.\
-                                     format(self.problem_id, num, 'vtk'))])
+                                     format(self.problem_id, num, kind))])
         # move each file
-        self.logger.info('[create_vtk_tar] moving {:d} files to {:s}'.\
+        self.logger.info('[move_to_tardir] moving {:d} files to {:s}'.\
                          format(len(id_files),tardir))
         for f in id_files: shutil.move(f,tardir)
 
-    def create_vtk_tar(self, num=None, remove_original=False):
-        """Creating tarred vtk from rearranged vtk output
-        or automatically move vtk files under id* to the rearranged vtk folders
+    def create_tar(self, num=None, remove_original=False, kind='vtk'):
+        """Creating tarred vtk/rst from rearranged output
 
         Parameters
         ----------
@@ -330,9 +334,11 @@ class LoadSim(object):
            Snapshot number, e.g., /basedir/vtk/xxxx
         remove_original : bool
            Remove original after tar it if True
+        kind : string
+           vtk or rst
         """
         # set tar file name
-        dirname = osp.join(self.basedir,'vtk')
+        dirname = osp.join(self.basedir,kind)
         fpattern = '{0:s}.{1:04d}.tar'
         tarname = osp.join(dirname, fpattern.format(self.problem_id, num))
         tardir = os.path.join(dirname,'{0:04d}'.format(num))
@@ -340,7 +346,7 @@ class LoadSim(object):
         # remove originals
         def remove_tardir():
             if osp.isdir(tardir) and remove_original:
-                self.logger_info('[create_vtk_tar] removing originals'
+                self.logger.info('[create_tar] removing originals'
                                  ' at {}'.format(tardir))
                 try:
                     shutil.rmtree(tardir)
@@ -350,12 +356,12 @@ class LoadSim(object):
         # check file existence
         if osp.isfile(tarname):
             # if tar file exists, remove original and quit
-            self.logger.info('[create_vtk_tar] tar file already exists')
+            self.logger.info('[create_tar] tar file already exists')
             remove_tardir()
             return
 
         # tar to vtk/problem_id.num.tar
-        self.logger.info('[create_vtk_tar] tarring vtk files')
+        self.logger.info('[create_tar] tarring {:s}'.format(tardir))
 
         tf = tarfile.open(tarname,'x')
         tf.add(tardir)


### PR DESCRIPTION
Now there is a new input file option `new_output_directory` per https://github.com/PrincetonUniversity/Athena-TIGRESS/pull/50 which will output vtk files from parallel jobs not under `id??/` folder but under `vtk/XXXX`. This means that not each rank writes everything under the same folder, but each snapshot will be written in the same folder. This change is mainly for jobs with a large number of tasks on machines with a limit to the number of files. The idea here is that each folder will be archived with a single tar file, which can be done easily while the simulations are running. Then, the reader will take a tarred file and read the data without untar it. To do that, I've added
* `create_vtk_tar` method for `LoadSim`, which will tar the vtk files under `vtk/XXXX` to `vtk/problem_id.XXXX.tar`
* `io/read_vtk_tar.py` to handle the tar file.

