### PR TITLE
Fix minor bug of wrong error raising

### DIFF
--- a/pyathena/load_sim.py
+++ b/pyathena/load_sim.py
@@ -753,6 +753,8 @@ class LoadSim(object):
                     if not hasattr(self, 'problem_id'):
                         self.problem_id = osp.basename(self.files['vtk_tar'][0]).split('.')[-2:]
                     self.nums = self.nums_tar
+            self.nums_vtk_all = list(set(self.nums)|set(self.nums_id0)|set(self.nums_tar))
+            self.nums_vtk_all.sort()
 
             # Check (joined) vtk file size
             sizes = [os.stat(f).st_size for f in self.files['vtk']]

--- a/pyathena/load_sim.py
+++ b/pyathena/load_sim.py
@@ -201,15 +201,15 @@ class LoadSim(object):
                 self.logger.info('[load_vtk]: Vtk file does not exist. ' + \
                                  'Try vtk in id0')
 
-            # Check if joined vtk (or vtk in id0) exists
-            self.fvtk = self._get_fvtk(kind[1], num, ivtk)
-            if self.fvtk is None or not osp.exists(self.fvtk):
-                self.logger.info('[load_vtk]: Vtk file does not exist.')
-
-            # Check if joined vtk (or vtk in id0) exists
-            self.fvtk = self._get_fvtk(kind[2], num, ivtk)
-            if self.fvtk is None or not osp.exists(self.fvtk):
-                self.logger.error('[load_vtk]: Vtk file does not exist.')
+            for kind_ in (kind[1], kind[2]):
+                # Check if joined vtk (or vtk in id0) exists
+                self.fvtk = self._get_fvtk(kind_, num, ivtk)
+                if self.fvtk is None or not osp.exists(self.fvtk):
+                    self.logger.info('[load_vtk]: Vtk file does not exist.')
+                else:
+                    self.logger.info('[load_vtk]: Found vtk file in "{}"\
+                                     '.format(kind_))
+                    break
 
         if self.fvtk.endswith('vtk'):
             if self.load_method == 'pyathena':


### PR DESCRIPTION
### Problem
When vtk file is not found in the primary search path, it looks for alternative paths. If vtk is found in the first alternative path, it sets `self.fvtk` to the found file. But then it goes on searching for the second alternative path, which overwrites `self.fvtk` with None if their is no vtk in the second alternative path.

### Fix
Break the loop when the vtk is found in an alternative path.

### Other minor change
Added `nums_vtk_all` variable that contains all vtk nums in joined, id0, or tar.