### PR TITLE
Use integer division to get indieces

### DIFF
--- a/pyathena/io/athena_read.py
+++ b/pyathena/io/athena_read.py
@@ -805,12 +805,12 @@ def athdf(filename, raw=False, data=None, quantities=None, dtype=None, level=Non
                 s = 2 ** (block_level - level)
 
                 # Calculate destination indices, without selection
-                il_d = block_location[0] * block_size[0] / s if nx1 > 1 else 0
-                jl_d = block_location[1] * block_size[1] / s if nx2 > 1 else 0
-                kl_d = block_location[2] * block_size[2] / s if nx3 > 1 else 0
-                iu_d = il_d + block_size[0] / s if nx1 > 1 else 1
-                ju_d = jl_d + block_size[1] / s if nx2 > 1 else 1
-                ku_d = kl_d + block_size[2] / s if nx3 > 1 else 1
+                il_d = block_location[0] * block_size[0] // s if nx1 > 1 else 0
+                jl_d = block_location[1] * block_size[1] // s if nx2 > 1 else 0
+                kl_d = block_location[2] * block_size[2] // s if nx3 > 1 else 0
+                iu_d = il_d + block_size[0] // s if nx1 > 1 else 1
+                ju_d = jl_d + block_size[1] // s if nx2 > 1 else 1
+                ku_d = kl_d + block_size[2] // s if nx3 > 1 else 1
 
                 # Calculate (restricted) source indices, with selection
                 il_s = max(il_d, i_min) - il_d
@@ -844,9 +844,9 @@ def athdf(filename, raw=False, data=None, quantities=None, dtype=None, level=Non
                 # Apply subsampling
                 if subsample:
                     # Calculate fine-level offsets (nearest cell at or below center)
-                    o1 = s/2 - 1 if nx1 > 1 else 0
-                    o2 = s/2 - 1 if nx2 > 1 else 0
-                    o3 = s/2 - 1 if nx3 > 1 else 0
+                    o1 = s//2 - 1 if nx1 > 1 else 0
+                    o2 = s//2 - 1 if nx2 > 1 else 0
+                    o3 = s//2 - 1 if nx3 > 1 else 0
 
                     # Assign values
                     for q, dataset, index in zip(quantities, quantity_datasets,
@@ -914,9 +914,9 @@ def athdf(filename, raw=False, data=None, quantities=None, dtype=None, level=Non
                                                                                block_num,
                                                                                k_s, j_s,
                                                                                i_s]
-                    loc1 = (nx1 > 1) * block_location[0] / s
-                    loc2 = (nx2 > 1) * block_location[1] / s
-                    loc3 = (nx3 > 1) * block_location[2] / s
+                    loc1 = (nx1 > 1) * block_location[0] // s
+                    loc2 = (nx2 > 1) * block_location[1] // s
+                    loc3 = (nx3 > 1) * block_location[2] // s
                     restricted_data[loc3, loc2, loc1] = True
 
             # Set level information for cells in this block


### PR DESCRIPTION
This PR fix a bug when reading AMR dataset.

In python3, `idx = a/b` gives float even if both `a` and `b` are integers. Using `idx` as an array index results an error. Change such expressions to the integer division `idx = a//b` resolves the issue.