### PR TITLE
Jupyter book

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -20,9 +20,9 @@ jobs:
     # Install dependencies
     - uses: conda-incubator/setup-miniconda@v2
       with:
-        activate-environment: pyglet
+        activate-environment: pyathena
         environment-file: env.yml
-        python-version: 3.10
+        python-version: 3.11
         auto-activate-base: false
 
     # check conda environment

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -21,6 +21,8 @@ jobs:
       with:
         python-version: '3.11'
         cache: 'pip' # caching pip dependencies
+        cache-dependency-path: requirements*.txt
+    - run: pip install --upgrade pip
     - run: pip install -r requirements.txt
 
     # Build the book

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
     - master
+    - jupyter-book
   pull_request:
     branches:
       - master
@@ -15,22 +16,12 @@ jobs:
   deploy-book:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-
-    # Install dependencies
-    - uses: conda-incubator/setup-miniconda@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
       with:
-        activate-environment: pyathena
-        environment-file: env.yml
-        python-version: 3.11
-        auto-activate-base: false
-
-    # check conda environment
-    - name: Check conda env
-      shell: bash -l {0}
-      run: |
-        conda info
-        conda list
+        python-version: '3.11'
+        cache: 'pip' # caching pip dependencies
+    - run: pip install -r requirements.txt
 
     # Build the book
     - name: Build the book

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -21,9 +21,8 @@ jobs:
       with:
         python-version: '3.11'
         cache: 'pip' # caching pip dependencies
-        cache-dependency-path: requirements*.txt
     - run: pip install --upgrade pip
-    - run: pip install -r requirements.txt
+    - run: pip install -r docs/requirements-docs.txt
 
     # Build the book
     - name: Build the book

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -21,6 +21,7 @@ jobs:
       with:
         python-version: '3.11'
         cache: 'pip' # caching pip dependencies
+        cache-dependency-path: '**/requirements*.txt'
     - run: pip install --upgrade pip
     - run: pip install -r docs/requirements-docs.txt
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 *.pyc
 *.swp
 nohup.*
+pyathena_env

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__
 *.swp
 nohup.*
 pyathena_env
+pyathena_env/*

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ __pycache__
 nohup.*
 pyathena_env
 pyathena_env/*
+docs/_build
+docs/_static
+.DS_Store

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,0 +1,14 @@
+yt
+matplotlib
+numpy
+astropy
+pandas
+xarray
+netCDF4
+healpy
+cmasher
+cmocean
+jupyter-book
+docutils==0.17.1
+tqdm
+periodictable

--- a/env.yml
+++ b/env.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - pip
   - jupyter
-  - yt=4.0
+  - yt
   - matplotlib
   - numpy
   - astropy


### PR DESCRIPTION
Updated workflows (confirmed that this works).

Additional steps you need are
* build jupyter-book locally
  - if you are in the python environment that works for pyathena, you may just do `pip install jupyter-book docutils==0.17.1`. Otherwise, you can install all requirements by `pip install -r docs/requirements-docs.txt` (I often found `conda` runs too slowly)
  ```sh
  $ PYTHONPATH=./ jupyter-book build docs/ --all`
  ```
  - when the build was successful, you will see the file path where the local HTML files are. 
* create gh-pages
  - let's use `ghp-import` as instructed at https://jupyterbook.org/en/stable/start/publish.html#publish-your-book-online-with-github-pages
  ```sh
  $ pip install ghp-import
  $ ghp-import -n -p -f docs/_build/html
  ```
* check the published page at https://jeonggyukim.github.io/pyathena
* finally, give read/write permission for the GitHub token: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#configuring-the-default-github_token-permissions

After these steps, you may be able to see automatic build and deployment under the `Actions` tap.