### PR TITLE
A simple wrapper around athena++ vtk reader

### DIFF
--- a/pyathena/load_sim.py
+++ b/pyathena/load_sim.py
@@ -17,7 +17,7 @@ import tarfile
 import shutil
 
 from .classic.vtk_reader import AthenaDataSet as AthenaDataSetClassic
-from .io.read_vtk import AthenaDataSet
+from .io.read_vtk import AthenaDataSet, read_vtk_athenapp
 from .io.read_vtk_tar import AthenaDataSetTar
 from .io.read_hdf5 import read_hdf5
 from .io.read_particles import read_partab, read_parhst
@@ -182,6 +182,16 @@ class LoadSim(object):
         # Override load_method
         if load_method is not None:
             self.load_method = load_method
+
+        if self.athena_pp:
+            def filter_vtk_files(kind='vtk', num=None):
+                def func(num):
+                    return lambda fname: '.{0:05d}.vtk'.format(num) in fname
+
+                return list(filter(func(num), self.files[kind]))
+
+            fnames = filter_vtk_files('vtk', num)
+            return read_vtk_athenapp(fnames)
 
         if not self.files['vtk_id0']:
             id0 = False
@@ -1346,4 +1356,3 @@ class LoadSimAll(object):
                            load_method=load_method,
                            units=units, verbose=verbose)
         return self.sim
-


### PR DESCRIPTION
Added simple code snippets to `LoadSim` for identifying athena++ vtk files and read them. Users can use `load_vtk` to read the data. It returns a dictionary containing arrays x1f, x2f, x3f, and other field variables. It works for both uniform grids and AMR data. The shape of x1f is (nmb, nx1_mb), field_var (nmb, nx1_mb, nx2_mb, nx3_mb). I have not tested for joined vtk files. 

In its current form it's not very much useful. We can make it more useful by adding an option for converting  to an xarray DataSet (especially for uniform grids data or data with a few levels of refinement). We can also improve the vanilla athena++ vtk reader (currently it doesn't even read the output time).

However, unless there are advantages of using vtk output (possibly as tarred format?) over hdf5 with athena++, it will not be worth putting much effort to improve this.