### PR TITLE
Minor enhancement to read hdf5

### DIFF
--- a/pyathena/io/read_hdf5.py
+++ b/pyathena/io/read_hdf5.py
@@ -29,6 +29,16 @@ def read_hdf5(filename, header_only=False, **kwargs):
     See Also
     --------
     io.athena_read.athdf
+    load_sim.LoadSim.load_hdf5
+
+    Examples
+    --------
+    >>> from pyathena.io import read_hdf5
+    >>> ds = read_hdf5("/path/to/hdf/file")
+
+    >>> from pyathena.load_sim import LoadSim
+    >>> s = LoadSim("/path/to/basedir")
+    >>> ds = read_hdf5(s.files['hdf5']['prim'][30])
     """
     if header_only:
         with h5py.File(filename, 'r') as f:

--- a/pyathena/load_sim.py
+++ b/pyathena/load_sim.py
@@ -279,6 +279,7 @@ class LoadSim(object):
 
         Examples
         --------
+        >>> from pyathena.load_sim import LoadSim
         >>> s = LoadSim("/path/to/basedir")
         >>> # Load everything at snapshot number 30.
         >>> ds = s.load_hdf5(30)

--- a/pyathena/load_sim.py
+++ b/pyathena/load_sim.py
@@ -279,17 +279,15 @@ class LoadSim(object):
 
         Examples
         --------
+        >>> s = LoadSim("/path/to/basedir")
         >>> # Load everything at snapshot number 30.
-        >>> ds = read_hdf5(30)
-
+        >>> ds = s.load_hdf5(30)
         >>> # Read the domain information only, without loading the fields.
-        >>> ds = read_hdf5(30, header_only=True)
-
+        >>> ds = s.load_hdf5(30, header_only=True)
         >>> # Load the selected fields.
-        >>> ds = read_hdf5(30, quantities=['dens', 'mom1', 'mom2', 'mom3'])
-
+        >>> ds = s.load_hdf5(30, quantities=['dens', 'mom1', 'mom2', 'mom3'])
         >>> # Load the selected region.
-        >>> ds = read_hdf5(30, x1_min=-0.5, x1_max=0.5, x2_min=1, x2_max=1.2)
+        >>> ds = s.load_hdf5(30, x1_min=-0.5, x1_max=0.5, x2_min=1, x2_max=1.2)
         """
 
         if num is None and ihdf5 is None:

--- a/pyathena/load_sim.py
+++ b/pyathena/load_sim.py
@@ -275,6 +275,18 @@ class LoadSim(object):
         Returns
         -------
         ds : xarray AthenaDataSet or yt datasets
+
+
+        Examples
+        --------
+        >>> # Load everything at snapshot number 30.
+        >>> ds = read_hdf5(30)
+
+        >>> # Read the domain information only, without loading the fields.
+        >>> ds = read_hdf5(30, header_only=True)
+
+        >>> # Load the selected fields.
+        >>> ds = read_hdf5(30, quantities=['dens', 'mom1', 'mom2', 'mom3'])
         """
 
         if num is None and ihdf5 is None:

--- a/pyathena/load_sim.py
+++ b/pyathena/load_sim.py
@@ -287,6 +287,9 @@ class LoadSim(object):
 
         >>> # Load the selected fields.
         >>> ds = read_hdf5(30, quantities=['dens', 'mom1', 'mom2', 'mom3'])
+
+        >>> # Load the selected region.
+        >>> ds = read_hdf5(30, x1_min=-0.5, x1_max=0.5, x2_min=1, x2_max=1.2)
         """
 
         if num is None and ihdf5 is None:

--- a/pyathena/util/transform.py
+++ b/pyathena/util/transform.py
@@ -21,9 +21,9 @@ def euler_rotation(vec, angles):
     angles = np.array(angles)
     r = Rotation.from_euler('zyx', -angles, degrees=False)
     rotmat = r.as_matrix()
-    vxp = rotmat[0,0]*vec[0] + rotmat[0,1]*vec[1] + rotmat[0,2]*vec[2]
-    vyp = rotmat[1,0]*vec[0] + rotmat[1,1]*vec[1] + rotmat[1,2]*vec[2]
-    vzp = rotmat[2,0]*vec[0] + rotmat[2,1]*vec[1] + rotmat[2,2]*vec[2]
+    vxp = rotmat[0, 0]*vec[0] + rotmat[0, 1]*vec[1] + rotmat[0, 2]*vec[2]
+    vyp = rotmat[1, 0]*vec[0] + rotmat[1, 1]*vec[1] + rotmat[1, 2]*vec[2]
+    vzp = rotmat[2, 0]*vec[0] + rotmat[2, 1]*vec[1] + rotmat[2, 2]*vec[2]
     return (vxp, vyp, vzp)
 
 
@@ -77,10 +77,10 @@ def to_spherical(vec, origin, newz=None):
     sin_ph, cos_ph = y/R, x/R
 
     # Avoid singularity
-    sin_th = sin_th.where(r!=0, other=0)
-    cos_th = cos_th.where(r!=0, other=0)
-    sin_ph = sin_ph.where(R!=0, other=0)
-    cos_ph = cos_ph.where(R!=0, other=0)
+    sin_th = sin_th.where(r != 0, other=0)
+    cos_th = cos_th.where(r != 0, other=0)
+    sin_ph = sin_ph.where(R != 0, other=0)
+    cos_ph = cos_ph.where(R != 0, other=0)
 
     # Transform Cartesian (vx, vy, vz) ->  spherical (v_r, v_th, v_phi)
     v_r = (vx*sin_th*cos_ph + vy*sin_th*sin_ph + vz*cos_th).rename('v_r')

--- a/pyathena/util/units.py
+++ b/pyathena/util/units.py
@@ -24,6 +24,7 @@ class Units(object):
             self.length = 1.0
             self.mass = 1.0
             self.time = 1.0
+            self.units_override = None
             return
 
         mH = 1.008*au.u


### PR DESCRIPTION
* `header_only` optional parameter allows reading only the domain information (including snapshot time), without loading actual data.
* Added example usage in `load_hdf5` function to demonstrate we can load e.g., only the selected field through the keywords arguments `quantities` or only the selected region through `x1_min`, `x1_max`, etc. that are passed to `athdf` function.
* Made `util.transform.to_spherical` more flexible by allowing arbitrary "z-axis" of the spherical coordinates.