### PR TITLE
Units class takes units_dict for tigris or custom unit systems.

### DIFF
--- a/pyathena/load_sim.py
+++ b/pyathena/load_sim.py
@@ -145,24 +145,27 @@ class LoadSim(object):
             except:
                 self.config_time = None
 
-        try:
-            muH = self.par['problem']['muH']
-            self.u = Units(kind='LV', muH=muH)
-        except KeyError:
-            try:
-                # Some old simulations run with new cooling may not have muH
-                # parameter printed out
-                if self.par['problem']['Z_gas'] != 1.0:
-                    self.logger.warning('Z_gas={0:g} but muH is not found in par. '.\
-                                        format(self.par['problem']['Z_gas']) +
-                                        'Caution with muH={0:s}'.format(muH))
-                self.u = units
-            except:
-                self.u = units
-                pass
         if not self.athena_pp:
+            try:
+                muH = self.par['problem']['muH']
+                self.u = Units(kind='LV', muH=muH)
+            except KeyError:
+                try:
+                    # Some old simulations run with new cooling may not have muH
+                    # parameter printed out
+                    if self.par['problem']['Z_gas'] != 1.0:
+                        self.logger.warning('Z_gas={0:g} but muH is not found in par. '.\
+                                            format(self.par['problem']['Z_gas']) +
+                                            'Caution with muH={0:s}'.format(muH))
+                    self.u = units
+                except:
+                    self.u = units
+                    pass
+
             # TODO(SMOON) Make DerivedFields work with athena++
             self.dfi = DerivedFields(self.par).dfi
+        else:
+            self.u = Units(kind='custom', units_dict=self.par['units'])
 
     def load_vtk(self, num=None, ivtk=None, id0=True, load_method=None):
         """Function to read Athena vtk file using pythena or yt and

--- a/pyathena/util/units.py
+++ b/pyathena/util/units.py
@@ -2,23 +2,45 @@ import astropy.units as au
 import astropy.constants as ac
 import numpy as np
 
-
 class Units(object):
     """Simple class for simulation unit.
 
     Msun, Lsun, etc.: physical constants in code unit
     """
-    def __init__(self, kind='LV', muH=1.4271):
+    def __init__(self, kind='LV', muH=1.4271, units_dict=None):
         """
         Parameters
         ----------
         kind : str
-           "LV" for (pc, km/s) or "LT" for (pc, Myr) or "cgs" for (cm, s),
-           or "code" for code unit.
+           "LV" for (pc, km/s) or "LT" for (pc, Myr) or "cgs" for (cm, s), or
+           "code" for code unit. For athena++ simulations, set to "custom"
+           and provide units_dict (<units> block in athinput file)
         muH : float
-            mean particle mass per H (for neutral gas).
-            Default value is 1.4271 (assuming solar metallicity).
+            Mean particle mass per H. Default value is 1.4271 (TIGRESS-classic).
+            See examples for other cases.
+        units_dict : dict
+            Dictionary containing <units> block in tigris athinput file.
+
+        Returns
+        -------
+        u : dict
+            Units instance
+
+        Example
+        -------
+        # Athena-TIGRESS with classic cooling
+        >>> u = Units(kind='LV', muH=1.4271)
+        # Athena-TIGRESS with NCR cooling
+        >>> u = Units(kind='LV', muH=1.4)
+        # TIGRIS "ism" unit system or any other custom unit system
+        >>> units_dict = {'units_system': 'ism',
+                          'mass_cgs': 4.91615563682836e+31,
+                          'length_cgs': 3.085678e+18,
+                          'time_cgs': 30856780000000,
+                          'mean_mass_per_hydrogen': 2.34262e-24}
+        >>> u = Units('custom', units_dict=units_dict)
         """
+        mH = (1.008*au.u).to('g')
         # If code units, set [L]=[M]=[T]=1 and return.
         if kind == 'code':
             self.length = 1.0
@@ -26,32 +48,51 @@ class Units(object):
             self.time = 1.0
             self.units_override = None
             return
-
-        mH = 1.008*au.u
-        if kind == 'LV':
+        elif kind == 'LV':
             self.muH = muH
             self.length = (1.0*au.pc).to('pc')
-            self.velocity = (1.0*au.km/au.s).to('km/s')
+            self.velocity = (1.0*au.km/au.s).to('km s-1')
             self.time = (self.length/self.velocity).cgs
         elif kind == 'LT':
             self.muH = muH
             self.length = (1.0*au.pc).to('pc')
             self.time = (1.0*au.Myr).to('Myr')
-            self.velocity = (self.length/self.time).to('km/s')
+            self.velocity = (self.length/self.time).to('km s-1')
         elif kind == 'cgs':
             self.length = 1.0*au.cm
             self.time = 1.0*au.s
-            self.velocity = (self.length/self.time).to('km/s')
+            self.velocity = (self.length/self.time).to('km s-1')
+        elif kind == 'custom':
+            if units_dict is None:
+                raise ValueError(f"Provide units_dict for athena++ simulations")
+
+            # Try manually setting the unit for the ism unit system
+            if units_dict['unit_system'] == 'ism':
+                self.mass = (units_dict['mass_cgs']*au.g).to('Msun')
+                self.length = (1.0*au.pc).to('pc')
+                self.velocity = (1.0*au.km/au.s).to('km s-1')
+                self.time = (self.length/self.velocity).to('Myr')
+            else:
+                self.mass = units_dict['mass_cgs']*au.g
+                self.length = units_dict['length_cgs']*au.cm
+                self.time = units_dict['time_cgs']*au.s
+                self.velocity = self.length/self.time
+            try:
+                self.muH = (units_dict['mean_mass_per_hydrogen']*au.g/mH).value
+            except KeyError:
+                pass
         else:
             raise ValueError(f"Unrecognized unit system: {kind}")
 
         self.mH = mH.to('g')
-        self.mass = (self.muH*mH*(self.length.to('cm').value)**3).to('Msun')
+        # mass unit set here if not "custom"
+        if not hasattr(self, 'mass'):
+            self.mass = (self.muH*mH*(self.length.to('cm').value)**3).to('Msun')
         self.density = (self.mass/self.length**3).cgs
         self.momentum = (self.mass*self.velocity).to('Msun km s-1')
         self.energy = (self.mass*self.velocity**2).cgs
         self.pressure = (self.density*self.velocity**2).cgs
-        self.energy_density = self.pressure.to('erg/cm**3')
+        self.energy_density = self.pressure.to('erg cm-3')
 
         self.mass_flux = (self.density*self.velocity).to('Msun kpc-2 yr-1')
         self.momentum_flux = (self.density*self.velocity**2
@@ -68,13 +109,13 @@ class Units(object):
         self.pc = self.length.to('pc').value
         self.kpc = self.length.to('kpc').value
         self.Myr = self.time.to('Myr').value
-        self.kms = self.velocity.to('km/s').value
+        self.kms = self.velocity.to('km s-1').value
         self.Msun = self.mass.to('Msun').value
         self.Lsun = (self.energy/self.time).to('Lsun').value
         self.erg = self.energy.to('erg').value
         self.eV = self.energy.to('eV').value
         self.s = self.time.to('s').value
-        self.pok = ((self.pressure/ac.k_B).to('cm**-3*K')).value
+        self.pok = ((self.pressure/ac.k_B).to('cm-3 K')).value
         self.muG = np.sqrt(4*np.pi*self.energy_density.cgs.value)/1e-6
 
         # For yt


### PR DESCRIPTION
For tigris simulations, the mass unit for "ism" unit system was set incorrectly (off by a factor 1.4).

- Improved `Units` class so that it can take `kind="custom"` argument (used for tigris simulations). In this case, `units_dict` should be provided (same as `<units>` block in athinput).
- Improved documentation.

Possible future improvements:

- [ ] Can implement `Units` class as dataclass and make it immutable.