### PR TITLE
Performance and style fixes in the transform module

### DIFF
--- a/pyathena/util/transform.py
+++ b/pyathena/util/transform.py
@@ -21,9 +21,9 @@ def euler_rotation(vec, angles):
     angles = np.array(angles)
     r = Rotation.from_euler('zyx', -angles, degrees=False)
     rotmat = r.as_matrix()
-    vxp = rotmat[0, 0]*vec[0] + rotmat[0, 1]*vec[1] + rotmat[0, 2]*vec[2]
-    vyp = rotmat[1, 0]*vec[0] + rotmat[1, 1]*vec[1] + rotmat[1, 2]*vec[2]
-    vzp = rotmat[2, 0]*vec[0] + rotmat[2, 1]*vec[1] + rotmat[2, 2]*vec[2]
+    vxp = rotmat[0, 2]*vec[2] + rotmat[0, 1]*vec[1] + rotmat[0, 0]*vec[0]
+    vyp = rotmat[1, 2]*vec[2] + rotmat[1, 1]*vec[1] + rotmat[1, 0]*vec[0]
+    vzp = rotmat[2, 2]*vec[2] + rotmat[2, 1]*vec[1] + rotmat[2, 0]*vec[0]
     return (vxp, vyp, vzp)
 
 

--- a/pyathena/util/transform.py
+++ b/pyathena/util/transform.py
@@ -76,11 +76,12 @@ def to_spherical(vec, origin, newz=None):
     sin_th, cos_th = R/r, z/r
     sin_ph, cos_ph = y/R, x/R
 
-    # Avoid singularity
+    # Break degeneracy by choosing arbitrary theta and phi at coordinate singularities
+    # \theta = 0 at r = 0, and \phi = 0 at R = 0.
     sin_th = sin_th.where(r != 0, other=0)
-    cos_th = cos_th.where(r != 0, other=0)
+    cos_th = cos_th.where(r != 0, other=1)
     sin_ph = sin_ph.where(R != 0, other=0)
-    cos_ph = cos_ph.where(R != 0, other=0)
+    cos_ph = cos_ph.where(R != 0, other=1)
 
     # Transform Cartesian (vx, vy, vz) ->  spherical (v_r, v_th, v_phi)
     v_r = (vx*sin_th*cos_ph + vy*sin_th*sin_ph + vz*cos_th).rename('v_r')
@@ -131,10 +132,11 @@ def to_cylindrical(vec, origin):
     # Move branch cut [-pi, pi] -> [0, 2pi]
     ph = ph.where(ph >= 0, other=ph + 2*np.pi)
     sin_ph, cos_ph = (y-y0)/R, (x-x0)/R
-    # Avoid singularity
+    # Break degeneracy by choosing arbitrary theta and phi at coordinate singularities
+    # \phi = 0 at R = 0.
     if x0 in x and y0 in y:
         sin_ph.loc[dict(x=x0, y=y0)] = 0
-        cos_ph.loc[dict(x=x0, y=y0)] = 0
+        cos_ph.loc[dict(x=x0, y=y0)] = 1
 
     # Transform Cartesian (vx, vy, vz) ->  cylindrical (v_R, v_phi, v_z)
     v_R = (vx*cos_ph + vy*sin_ph).rename('v_R')


### PR DESCRIPTION
1. In curvilinear coordinates, some *components* of a vector at the coordinate singularities are ill-defined. I think it is better to make an arbitrary choice of \theta and \phi, rather than just zeroing out the components.

2. Very simple fix in `transform.euler_rotation` solves #30 by aligning the data in z, y, x order.