### PR TITLE
Add missing attribute to loadsim

### DIFF
--- a/pyathena/load_sim.py
+++ b/pyathena/load_sim.py
@@ -271,7 +271,7 @@ class LoadSim(LoadSimBase):
             'files', 'athena_pp', 'par', 'problem_id', 'out_fmt',
             'nums',
             # particle (Athena++)
-            'nums_partab','partags', '_partab_partag_def', 'pids',
+            'nums_partab','partags', '_partab_partag_def', 'pids', 'partab_outid',
             # hdf5 (Athena++)
             'nums_hdf5', 'hdf5_outid', 'hdf5_outvar', '_hdf5_outid_def',
             '_hdf5_outvar_def',


### PR DESCRIPTION
One of the `FindFiles` attributes, `partab_outid`, was not properly transferred to `LoadSim`, such that load_partab is not working. This PR fixes the bug.