### PR TITLE
Add particle binary reader

### DIFF
--- a/pyathena/find_files.py
+++ b/pyathena/find_files.py
@@ -182,7 +182,6 @@ class FindFiles(object):
                         par_id = int(k.strip('particle')) - 1
                         partag = 'par{}'.format(par_id)
                         self.partags.append(partag)
-                        self._partab_partag_def = partag
 
                 # if there are hdf5 outputs, save some info
                 if self.out_fmt.count('hdf5') > 0:

--- a/pyathena/find_files.py
+++ b/pyathena/find_files.py
@@ -69,6 +69,10 @@ class FindFiles(object):
         ('partab', '*.out?.?????.par?.tab'),
         ('*.out?.?????.par?.tab',)]
 
+    patterns['parbin'] = [
+        ('parbin', '*.out?.?????.par?.parbin'),
+        ('*.out?.?????.par?.parbin',)]
+
     patterns['parhst'] = [
         ('parhst', '*.par*.csv'),
         ('*.par*.csv',)]
@@ -118,6 +122,7 @@ class FindFiles(object):
             self.find_starpar_vtk()
         else:
             self.find_partab()
+            self.find_parbin()
             self.find_parhst()
 
         self.find_rst()
@@ -201,6 +206,12 @@ class FindFiles(object):
                     for k in self.par.keys():
                         if k.startswith('output') and self.par[k]['file_type'] == 'partab':
                             self.partab_outid = int(re.split(r'(\d+)',k)[1])
+
+                # if there are parbin outputs, save some info
+                if 'parbin' in self.out_fmt:
+                    for k in self.par.keys():
+                        if k.startswith('output') and self.par[k]['file_type'] == 'parbin':
+                            self.parbin_outid = int(re.split(r'(\d+)',k)[1])
 
             else:
                 for k in self.par.keys():
@@ -306,6 +317,30 @@ class FindFiles(object):
                     self.logger.info('partab ({0:s}): {1:s} nums: {2:d}-{3:d}'.format(
                         partag, osp.dirname(self.files['partab'][partag][0]),
                         self.nums_partab[partag][0], self.nums_partab[partag][-1]))
+
+    def find_parbin(self):
+        # Find parbin files
+        if 'parbin' in self.out_fmt:
+            self.files['parbin'] = dict()
+            self.nums_parbin = dict()
+            for partag in self.partags:
+                parbin_patterns_ = []
+                for p in self.patterns['parbin']:
+                    p = list(p)
+                    p[-1] = p[-1].replace('par?', partag)
+                    parbin_patterns_.append(tuple(p))
+                self.files['parbin'][partag] = self.find_match(parbin_patterns_)
+                if not self.files['parbin'][partag]:
+                    self.logger.warning(
+                        'parbin ({0:s}) files not found in {1:s}'.\
+                        format(partag, self.basedir))
+                    self.nums_parbin[partag] = None
+                else:
+                    self.nums_parbin[partag] = [int(f[-17:-12])
+                                                 for f in self.files['parbin'][partag]]
+                    self.logger.info('parbin ({0:s}): {1:s} nums: {2:d}-{3:d}'.format(
+                        partag, osp.dirname(self.files['parbin'][partag][0]),
+                        self.nums_parbin[partag][0], self.nums_parbin[partag][-1]))
 
     def find_parhst(self):
         if [k for k in self.par.keys() if k.startswith('particle') and

--- a/pyathena/io/athena_read.py
+++ b/pyathena/io/athena_read.py
@@ -306,7 +306,7 @@ def parbin(fname, verbose=False):
             realprop = np.array(realprop).reshape(npartot, nreal)
         df_intprop = pd.DataFrame(data=intprop, columns=header[:nint])
         df_realprop = pd.DataFrame(data=realprop, columns=header[nint:])
-        pds = df_intprop.join(df_realprop).set_index("pid").sort_index()
+        pds = df_intprop.join(df_realprop)
         return pds
 
 

--- a/pyathena/io/read_particles.py
+++ b/pyathena/io/read_particles.py
@@ -22,6 +22,7 @@ def read_partab(filename, **kwargs):
     """
     ds = partab(filename, **kwargs)
     ds.set_index('pid', inplace=True)
+    ds.sort_index(inplace=True)
 
     return ds
 
@@ -43,9 +44,9 @@ def read_parbin(filename, **kwargs):
     """
     ds = parbin(filename, **kwargs)
     ds.set_index('pid', inplace=True)
+    ds.sort_index(inplace=True)
 
     return ds
-
 
 def read_parhst(filename, **kwargs):
     """Read individual particle history

--- a/pyathena/io/read_particles.py
+++ b/pyathena/io/read_particles.py
@@ -1,7 +1,7 @@
 """Module containing particle output readers"""
 
 
-from .athena_read import partab
+from .athena_read import partab, parbin
 from pandas import read_csv
 
 def read_partab(filename, **kwargs):
@@ -24,6 +24,28 @@ def read_partab(filename, **kwargs):
     ds.set_index('pid', inplace=True)
 
     return ds
+
+def read_parbin(filename, **kwargs):
+    """Read particle output
+
+    Parameters
+    ----------
+    filename : str
+        Data filename
+    **kwargs : dict, optional
+        Extra arguments passed to parbin. Refer to parbin documentation for
+        a list of all possible arguments.
+
+    Returns
+    -------
+    ds : pandas.DataFrame
+        Particle data
+    """
+    ds = parbin(filename, **kwargs)
+    ds.set_index('pid', inplace=True)
+
+    return ds
+
 
 def read_parhst(filename, **kwargs):
     """Read individual particle history

--- a/pyathena/load_sim.py
+++ b/pyathena/load_sim.py
@@ -271,7 +271,7 @@ class LoadSim(LoadSimBase):
             'files', 'athena_pp', 'par', 'problem_id', 'out_fmt',
             'nums',
             # particle (Athena++)
-            'nums_partab','partags', '_partab_partag_def', 'pids', 'partab_outid',
+            'nums_partab', 'partags', 'pids', 'partab_outid',
             # hdf5 (Athena++)
             'nums_hdf5', 'hdf5_outid', 'hdf5_outvar', '_hdf5_outid_def',
             '_hdf5_outvar_def',
@@ -493,7 +493,7 @@ class LoadSim(LoadSimBase):
         return self.ds
 
     def load_partab(self, num=None, ipartab=None,
-                    partag=None, **kwargs):
+                    partag='par0', **kwargs):
         """Read Athena++ partab file.
 
         Parameters
@@ -514,9 +514,6 @@ class LoadSim(LoadSimBase):
         """
         if num is None and ipartab is None:
             raise ValueError('Specify either num or ipartab')
-
-        if partag is None:
-            partag = self._partab_partag_def
 
         self.fpartab = self._get_fpartab(self.partab_outid, partag, num, ipartab)
         if self.fpartab is None or not osp.exists(self.fpartab):


### PR DESCRIPTION
This PR adds a function to read particle binary output files introduced in https://github.com/PrincetonUniversity/tigris/pull/159.

I made a small change to the original reader introduced in https://github.com/PrincetonUniversity/tigris/pull/159, to make return data structure of `read_parbin` identical to `read_partab` (both in Pandas DataFrame.)