### PR TITLE
Dask-xarray support

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -13,6 +13,7 @@ dependencies:
   - astropy
   - pandas
   - xarray
+  - dask
   - netCDF4
   - healpy
   - cmasher

--- a/pyathena/io/read_hdf5.py
+++ b/pyathena/io/read_hdf5.py
@@ -86,72 +86,72 @@ def read_hdf5_dask(filename, chunksize=(512, 512, 512)):
     chunksize : tuple of int, optional
         Dask chunk size along (x, y, z) directions. Default is (512, 512, 512).
     """
-    f = h5py.File(filename, 'r')
 
-    # Read Mesh information
-    block_size = f.attrs['MeshBlockSize']
-    mesh_size = f.attrs['RootGridSize']
-    num_blocks = mesh_size // block_size  # Assuming uniform grid
+    with h5py.File(filename, 'r') as f:
+        # Read Mesh information
+        block_size = f.attrs['MeshBlockSize']
+        mesh_size = f.attrs['RootGridSize']
+        num_blocks = mesh_size // block_size  # Assuming uniform grid
 
-    if num_blocks.prod() != f.attrs['NumMeshBlocks']:
-        raise ValueError("Number of blocks does not match the attribute")
+        if num_blocks.prod() != f.attrs['NumMeshBlocks']:
+            raise ValueError("Number of blocks does not match the attribute")
 
-    # Array of logical locations, arranged by Z-ordering
-    # (lx1, lx2, lx3)
-    # (  0,   0,   0)
-    # (  1,   0,   0)
-    # (  0,   1,   0)
-    # ...
-    logical_loc = f['LogicalLocations']
+        # Array of logical locations, arranged by Z-ordering
+        # (lx1, lx2, lx3)
+        # (  0,   0,   0)
+        # (  1,   0,   0)
+        # (  0,   1,   0)
+        # ...
+        logical_loc = f['LogicalLocations']
 
-    # Number of MeshBlocks per chunk along each dimension.
-    nblock_per_chunk = np.array(chunksize) // block_size
-    chunksize_read = (1, nblock_per_chunk.prod(), *block_size)
+        # Number of MeshBlocks per chunk along each dimension.
+        nblock_per_chunk = np.array(chunksize) // block_size
+        chunksize_read = (1, nblock_per_chunk.prod(), *block_size)
 
-    # lazy load from HDF5
-    ds = []
-    for dsetname in f.attrs['DatasetNames']:
-        darr = da.from_array(f[dsetname], chunks=chunksize_read)
-        if len(darr.shape) != 5:
-            # Expected shape: (nvar, nblock, z, y, x)
-            raise ValueError("Invalid shape of the dataset")
-        ds += [var for var in darr]
+        # lazy load from HDF5
+        ds = []
+        for dsetname in f.attrs['DatasetNames']:
+            darr = da.from_array(f[dsetname], chunks=chunksize_read)
+            if len(darr.shape) != 5:
+                # Expected shape: (nvar, nblock, z, y, x)
+                raise ValueError("Invalid shape of the dataset")
+            ds += [var for var in darr]
 
-    def _reorder_rechunk(var):
-        """
-        Loop over the MeshBlocks and place them to correct logical locations
-        in 3D Cartesian space. Then, merge them into a single dask array.
-        """
-        reordered = np.empty(num_blocks[::-1], dtype=object)
-        for gid in range(num_blocks.prod()):
-            lx1, lx2, lx3 = logical_loc[gid]  # Correct Cartesian coordinates
-            reordered[lx3, lx2, lx1] = var[gid, ...]  # Assign the correct block
-        # Merge into a single array
-        return da.block(reordered.tolist()).rechunk(chunksize)
-    # Apply the rechunking function to all variables
-    ds = list(map(_reorder_rechunk, ds))
+        def _reorder_rechunk(var):
+            """
+            Loop over the MeshBlocks and place them to correct logical locations
+            in 3D Cartesian space. Then, merge them into a single dask array.
+            """
+            reordered = np.empty(num_blocks[::-1], dtype=object)
+            for gid in range(num_blocks.prod()):
+                lx1, lx2, lx3 = logical_loc[gid]  # Correct Cartesian coordinates
+                reordered[lx3, lx2, lx1] = var[gid, ...]  # Assign the correct block
+            # Merge into a single array
+            return da.block(reordered.tolist()).rechunk(chunksize)
+        # Apply the rechunking function to all variables
+        ds = list(map(_reorder_rechunk, ds))
 
-    # Convert to xarray object
-    varnames = list(map(lambda x: x.decode('ASCII'), f.attrs['VariableNames']))
-    variables = [(['z', 'y', 'x'], d) for d in ds]
-    coordnames = ['x1v', 'x2v', 'x3v']
+        # Convert to xarray object
+        varnames = list(map(lambda x: x.decode('ASCII'), f.attrs['VariableNames']))
+        variables = [(['z', 'y', 'x'], d) for d in ds]
+        coordnames = ['x1v', 'x2v', 'x3v']
 
-    # Calculate coordinates
-    # Borrowed and slightly modified from pyathena.io.athdf
-    coords = {}
-    for i, (nrbx, xv) in enumerate(zip(num_blocks, coordnames)):
-        coords[xv] = np.empty(mesh_size[i])
-        for n_block in range(nrbx):
-            sample_block = np.where(logical_loc[:, i] == n_block)[0][0]
-            index_low = n_block * block_size[i]
-            index_high = index_low + block_size[i]
-            coords[xv][index_low:index_high] = f[xv][sample_block, :]
+        # Calculate coordinates
+        # Borrowed and slightly modified from pyathena.io.athdf
+        coords = {}
+        for i, (nrbx, xv) in enumerate(zip(num_blocks, coordnames)):
+            coords[xv] = np.empty(mesh_size[i])
+            for n_block in range(nrbx):
+                sample_block = np.where(logical_loc[:, i] == n_block)[0][0]
+                index_low = n_block * block_size[i]
+                index_high = index_low + block_size[i]
+                coords[xv][index_low:index_high] = f[xv][sample_block, :]
 
-    # If uniform grid, store cell spacing.
-    attrs = dict(f.attrs)
-    attrs['dx1'] = np.diff(f.attrs['RootGridX1'])[0] / mesh_size[0]
-    attrs['dx2'] = np.diff(f.attrs['RootGridX2'])[0] / mesh_size[1]
-    attrs['dx3'] = np.diff(f.attrs['RootGridX3'])[0] / mesh_size[2]
+        # If uniform grid, store cell spacing.
+        attrs = dict(f.attrs)
+        attrs['dx1'] = np.diff(f.attrs['RootGridX1'])[0] / mesh_size[0]
+        attrs['dx2'] = np.diff(f.attrs['RootGridX2'])[0] / mesh_size[1]
+        attrs['dx3'] = np.diff(f.attrs['RootGridX3'])[0] / mesh_size[2]
 
     ds = xr.Dataset(
         data_vars=dict(zip(varnames, variables)),

--- a/pyathena/io/read_hdf5.py
+++ b/pyathena/io/read_hdf5.py
@@ -4,11 +4,12 @@ Read athena++ hdf5 file
 
 import xarray as xr
 import numpy as np
+import dask.array as da
 import h5py
 
 from .athena_read import athdf
 
-def read_hdf5(filename, header_only=False, **kwargs):
+def read_hdf5(filename, header_only=False, chunks=None, **kwargs):
     """Read Athena hdf5 file and convert it to xarray Dataset
 
     Parameters
@@ -17,6 +18,8 @@ def read_hdf5(filename, header_only=False, **kwargs):
         Data filename
     header_only : bool
         Flag to read only attributes, not data.
+    chunks : (dict or None), default: None
+        If provided, used to load the data into dask arrays.
     **kwargs : dict, optional
         Extra arguments passed to athdf. Refer to athdf documentation for
         a list of all possible arguments.
@@ -40,31 +43,115 @@ def read_hdf5(filename, header_only=False, **kwargs):
     >>> s = LoadSim("/path/to/basedir")
     >>> ds = read_hdf5(s.files['hdf5']['prim'][30])
     """
-    if header_only:
-        with h5py.File(filename, 'r') as f:
-            data = {}
-            for key in f.attrs:
-                data[str(key)] = f.attrs[key]
-            return data
+    if chunks is not None:
+        return read_hdf5_dask(filename, (chunks['x'], chunks['y'], chunks['z']))
+    else:
+        if header_only:
+            with h5py.File(filename, 'r') as f:
+                data = {}
+                for key in f.attrs:
+                    data[str(key)] = f.attrs[key]
+                return data
 
-    ds = athdf(filename, **kwargs)
+        ds = athdf(filename, **kwargs)
+
+        # Convert to xarray object
+        possibilities = set(map(lambda x: x.decode('ASCII'), ds['VariableNames']))
+        varnames = {var for var in possibilities if var in ds}
+        variables = [(['z', 'y', 'x'], ds[varname]) for varname in varnames]
+        attr_keys = (set(ds.keys()) - varnames
+                     - {'VariableNames','x1f','x2f','x3f','x1v','x2v','x3v'})
+        attrs = {attr_key:ds[attr_key] for attr_key in attr_keys}
+
+        # If uniform grid, store cell spacing.
+        if ds['MaxLevel'] == 0:
+            attrs['dx1'] = np.diff(ds['RootGridX1'])[0] / ds['RootGridSize'][0]
+            attrs['dx2'] = np.diff(ds['RootGridX2'])[0] / ds['RootGridSize'][1]
+            attrs['dx3'] = np.diff(ds['RootGridX3'])[0] / ds['RootGridSize'][2]
+
+        ds = xr.Dataset(
+            data_vars=dict(zip(varnames, variables)),
+            coords=dict(x=ds['x1v'], y=ds['x2v'], z=ds['x3v']),
+            attrs=attrs
+        )
+        return ds
+
+def read_hdf5_dask(filename, chunksize=(512, 512, 512)):
+    """Read Athena++ hdf5 file and convert it to dask-xarray Dataset
+
+    Parameters
+    ----------
+    filename : str
+        Data filename
+    chunksize : tuple of int, optional
+        Dask chunk size along (x, y, z) directions. Default is (512, 512, 512).
+    """
+    f = h5py.File(filename, 'r')
+
+    # Read Mesh information
+    block_size = f.attrs['MeshBlockSize']
+    mesh_size = f.attrs['RootGridSize']
+    num_blocks = mesh_size // block_size  # Assuming uniform grid
+
+    if num_blocks.prod() != f.attrs['NumMeshBlocks']:
+        raise ValueError("Number of blocks does not match the attribute")
+
+    # Array of logical locations, arranged by Z-ordering
+    # (lx1, lx2, lx3)
+    # (  0,   0,   0)
+    # (  1,   0,   0)
+    # (  0,   1,   0)
+    # ...
+    logical_loc = f['LogicalLocations']
+
+    # Number of MeshBlocks per chunk along each dimension.
+    nblock_per_chunk = np.array(chunksize) // block_size
+    chunksize_read = (1, nblock_per_chunk.prod(), *block_size)
+
+    # lazy load from HDF5 and concatenate hydro variables and magnetic fields
+    ds = []
+    for dsetname in f.attrs['DatasetNames']:
+        ds.append(da.from_array(f[dsetname], chunks=chunksize_read))
+    ds = da.concatenate(ds)
+
+    # Loop over the MeshBlocks and place them to correct logical locations
+    # in 3D Cartesian space.
+    reordered = np.empty(num_blocks[::-1], dtype=object)
+    for gid in range(num_blocks.prod()):
+        lx1, lx2, lx3 = logical_loc[gid]  # Correct Cartesian coordinates
+        reordered[lx3, lx2, lx1] = ds[:, gid, ...]  # Assign the correct block
+
+    # Stack them together properly
+    ds = da.block(reordered.tolist())  # Merge into a single array
+    ds = ds.rechunk([ds.shape[0], *chunksize])
 
     # Convert to xarray object
-    possibilities = set(map(lambda x: x.decode('ASCII'), ds['VariableNames']))
-    varnames = {var for var in possibilities if var in ds}
-    variables = [(['z', 'y', 'x'], ds[varname]) for varname in varnames]
-    attr_keys = (set(ds.keys()) - varnames
-                 - {'VariableNames','x1f','x2f','x3f','x1v','x2v','x3v'})
-    attrs = {attr_key:ds[attr_key] for attr_key in attr_keys}
+    varnames = list(map(lambda x: x.decode('ASCII'), f.attrs['VariableNames']))
+    variables = [(['z', 'y', 'x'], ds[i]) for i, _ in enumerate(varnames)]
+    coordnames = ['x1v', 'x2v', 'x3v']
+
+    # Calculate coordinates
+    # Borrowed and slightly modified from pyathena.io.athdf
+    coords = {}
+    for i, (nrbx, xv) in enumerate(zip(num_blocks, coordnames)):
+        coords[xv] = np.empty(mesh_size[i])
+        for n_block in range(nrbx):
+            sample_block = np.where(logical_loc[:, i] == n_block)[0][0]
+            index_low = n_block * block_size[i]
+            index_high = index_low + block_size[i]
+            coords[xv][index_low:index_high] = f[xv][sample_block, :]
 
     # If uniform grid, store cell spacing.
-    if ds['MaxLevel'] == 0:
-        attrs['dx1'] = np.diff(ds['RootGridX1'])[0] / ds['RootGridSize'][0]
-        attrs['dx2'] = np.diff(ds['RootGridX2'])[0] / ds['RootGridSize'][1]
-        attrs['dx3'] = np.diff(ds['RootGridX3'])[0] / ds['RootGridSize'][2]
+    attrs = dict(f.attrs)
+    attrs['dx1'] = np.diff(f.attrs['RootGridX1'])[0] / mesh_size[0]
+    attrs['dx2'] = np.diff(f.attrs['RootGridX2'])[0] / mesh_size[1]
+    attrs['dx3'] = np.diff(f.attrs['RootGridX3'])[0] / mesh_size[2]
+
     ds = xr.Dataset(
         data_vars=dict(zip(varnames, variables)),
-        coords=dict(x=ds['x1v'], y=ds['x2v'], z=ds['x3v']),
+        coords=dict(x=coords['x1v'], y=coords['x2v'], z=coords['x3v']),
         attrs=attrs
     )
+
+
     return ds

--- a/pyathena/io/read_vtk.py
+++ b/pyathena/io/read_vtk.py
@@ -5,6 +5,7 @@ Read athena vtk file
 
 import os
 import os.path as osp
+from packaging.version import Version
 import glob, struct
 import numpy as np
 import xarray as xr
@@ -432,7 +433,11 @@ class AthenaDataSet(object):
             fp.readline() # skip header
             if fm['read_table']:
                 fp.readline()
-            grid['data'][field]= (np.frombuffer(buffer=fp.read(fm['dsize']),dtype=fm['dtype'])).newbyteorder() # New method for converting the binary data
+            if Version(np.__version__) >= Version('2.0.0'):
+                arr = np.frombuffer(buffer=fp.read(fm['dsize']),dtype=fm['dtype']) # New method for converting the binary data
+                grid['data'][field]= arr.view(arr.dtype.newbyteorder()) # New method for converting the binary data
+            else:
+                grid['data'][field]= (np.frombuffer(buffer=fp.read(fm['dsize']),dtype=fm['dtype'])).newbyteorder() # New method for converting the binary data
             fp.close()
 
             if fm['nvar'] == 1:

--- a/pyathena/util/transform.py
+++ b/pyathena/util/transform.py
@@ -194,9 +194,9 @@ def to_cylindrical(vec, origin):
     v_R.coords['ph'] = ph
     v_ph.coords['ph'] = ph
     v_z.coords['ph'] = ph
-    v_R.coords['z'] = z
-    v_ph.coords['z'] = z
-    v_z.coords['z'] = z
+    v_R.coords['z'] = vx.z  # Note that we do not want to set z coordinate z - z0.
+    v_ph.coords['z'] = vx.z # Use original z coordinates.
+    v_z.coords['z'] = vx.z
     vec_cyl = (v_R, v_ph, v_z)
     return R, vec_cyl
 

--- a/pyathena/util/transform.py
+++ b/pyathena/util/transform.py
@@ -86,9 +86,9 @@ def to_spherical(vec, origin, newz=None):
 #        if ((np.array(newz)**2).sum() == 0):
 #            raise ValueError("new z axis vector should not be a null vector")
 
-        # Rotate to align z axis
+        # Obtain Euler angles to rotate z-axis to newz
         newz_mag = np.sqrt(newz[0]**2 + newz[1]**2 + newz[2]**2)
-        alpha = np.arccos(-newz[1] / np.sqrt(newz_mag**2 - newz[2]**2))
+        alpha = (np.arctan2(newz[1], newz[0]) + np.pi/2) % (2*np.pi)
         beta = np.arccos(newz[2] / newz_mag)
         vx, vy, vz = euler_rotation((vx, vy, vz), [alpha, beta, 0])
         x, y, z = euler_rotation((x, y, z), [alpha, beta, 0])

--- a/pyathena/util/transform.py
+++ b/pyathena/util/transform.py
@@ -49,11 +49,11 @@ def to_spherical(vec, origin, newz=None):
 
     Parameters
     ----------
-    vec : tuple, list, or numpy.ndarray of xarray.DataArray
+    vec : tuple or list of xarray.DataArray
         (vx, vy, vz) representing Cartesian vector components.
-    origin : tuple, list, or numpy.ndarray
+    origin : tuple or list
         (x0, y0, z0) representing the origin of the spherical coords.
-    newz : tuple or list, or numpy.ndarray, optional
+    newz : tuple or list, optional
         Cartesian components of the z-axis vector for the spherical
         coordinates. If not given, it is assumed to be (0, 0, 1).
 
@@ -63,7 +63,7 @@ def to_spherical(vec, origin, newz=None):
         Binned radius
     vec_sph : tuple
         (v_r, v_th, v_ph) representing the three components of
-        velocities in spherical coords.
+        vector in spherical coords.
     """
     vx, vy, vz = vec
     x0, y0, z0 = origin
@@ -82,13 +82,14 @@ def to_spherical(vec, origin, newz=None):
     x, y, z = x - x0, y - y0, z - z0
 
     if newz is not None:
-        if ((np.array(newz)**2).sum() == 0):
-            raise ValueError("new z axis vector should not be a null vector")
+        # Let's avoid eager computation at the cost of safety.
+#        if ((np.array(newz)**2).sum() == 0):
+#            raise ValueError("new z axis vector should not be a null vector")
 
         # Rotate to align z axis
-        zhat = np.array([0, 0, 1])
-        alpha = np.arctan2(newz[1], newz[0])
-        beta = np.arccos(np.dot(newz, zhat) / np.sqrt(np.dot(newz, newz)))
+        newz_mag = np.sqrt(newz[0]**2 + newz[1]**2 + newz[2]**2)
+        alpha = np.arccos(-newz[1] / np.sqrt(newz_mag**2 - newz[2]**2))
+        beta = np.arccos(newz[2] / newz_mag)
         vx, vy, vz = euler_rotation((vx, vy, vz), [alpha, beta, 0])
         x, y, z = euler_rotation((x, y, z), [alpha, beta, 0])
 

--- a/pyathena/util/transform.py
+++ b/pyathena/util/transform.py
@@ -194,8 +194,8 @@ def groupby_bins(dat, coord, edges, cumulative=False):
         binned array
     """
     dat = dat.transpose(*sorted(list(dat.dims), reverse=True))
-    fc = dat[coord].data.flatten()  # flattened coordinates
-    fd = dat.data.flatten()  # flattened data
+    fc = dat[coord].data  # coordinates
+    fd = dat.data  # data
     bin_sum = np.histogram(fc, edges, weights=fd)[0]
     bin_cnt = np.histogram(fc, edges)[0]
     if cumulative:


### PR DESCRIPTION
# Dask-xarray support

**This PR is work in progress.**

Make `pyathena` support dask-backed `xarray`. This means

* Parallel analysis using domain decomposition (even multiple nodes)
* Lazy loading of hdf5 files

This will resolve #42.

## TODOs

- [x] Enable `read_hdf5` to read `.athdf` file into dask-backed xarray dataset.
- [x] Make functions in `transform` module support dask-backed xarray.
  - [x] `euler_rotation` : Automatically supports dask as it consists of numpy ufuncs.
  - [x] `to_spherical`
  - [x] `to_cylindrical`
  - [x] `groupby_bins`
  - [x] ~~`fast_groupby_bins` : fast_histogram is not numpy ufunc. Consider flox-accelerated xarray(dask) groupby_bins.~~ No longer needed, as 1) `np.histogram` **using uniform bins** is efficient enough, and 2) `fast_histogram` is not compatible with dask.
- [x] Check whether it works for multiple nodes.