### PR TITLE
Made the hdf5 dask reader compatible with ghost zone output

### DIFF
--- a/pyathena/io/read_hdf5.py
+++ b/pyathena/io/read_hdf5.py
@@ -21,6 +21,8 @@ def read_hdf5(filename, header_only=False, chunks=None, num_ghost=0, **kwargs):
         Flag to read only attributes, not data.
     chunks : (dict or None), default: None
         If provided, used to load the data into dask arrays.
+    num_ghost : int, optional
+        Number of ghost zones in the output. Default is 0.
     **kwargs : dict, optional
         Extra arguments passed to athdf. Refer to athdf documentation for
         a list of all possible arguments.
@@ -56,7 +58,7 @@ def read_hdf5(filename, header_only=False, chunks=None, num_ghost=0, **kwargs):
                     data[str(key)] = f.attrs[key]
                 return data
 
-        ds = athdf(filename, **kwargs)
+        ds = athdf(filename, num_ghost=num_ghost, **kwargs)
 
         # Convert to xarray object
         possibilities = set(map(lambda x: x.decode('ASCII'), ds['VariableNames']))

--- a/pyathena/io/read_hdf5.py
+++ b/pyathena/io/read_hdf5.py
@@ -89,6 +89,8 @@ def read_hdf5_dask(filename, chunksize=(512, 512, 512), num_ghost=0):
         Data filename
     chunksize : tuple of int, optional
         Dask chunk size along (x, y, z) directions. Default is (512, 512, 512).
+    num_ghost : int, optional
+        Number of ghost zones in the output. Default is 0.
     """
     f = h5py.File(filename, 'r')
 


### PR DESCRIPTION
I added an `num_ghost` option when reading a hdf5 file with dask. An example usage is

```python
s = pa.LoadSim("/scratch/gpfs/changgoo/tigress_classic/crrun-r_ret0-icpx-b")
outid=s.hdf5_outid[0]
ghost = s.par[f"output{outid}"]["ghost_zones"] == "true"
num_ghost = s.par["configure"]["Number_of_ghost_cells"]
ds = s.load_hdf5(200, chunks=dict(x=64, y=64, z=64), num_ghost=num_ghost)
```

This shouldn't break anything without ghost zone output.