### PR TITLE
Divide by zero

### DIFF
--- a/pyathena/load_sim.py
+++ b/pyathena/load_sim.py
@@ -910,7 +910,7 @@ class LoadSim(LoadSimBase):
                 else:
                     savdir = osp.join(cls.savdir, prefix)
 
-                if kwargs['filebase'] is not None:
+                if 'filebase' in kwargs and kwargs['filebase'] is not None:
                     filebase = kwargs['filebase']
                 else:
                     filebase = prefix

--- a/pyathena/util/transform.py
+++ b/pyathena/util/transform.py
@@ -246,7 +246,8 @@ def groupby_bins(dat, coord, bins, range=None, cumulative=False, skipna=False):
     if cumulative:
         bin_sum = np.cumsum(bin_sum)
         bin_cnt = np.cumsum(bin_cnt)
-    res = bin_sum / bin_cnt
+    res = np.divide(bin_sum, bin_cnt,
+                    out=np.full_like(bin_sum, np.nan), where=(bin_cnt!=0))
     # set new coordinates at the bin center
     centers = 0.5*(edges[1:] + edges[:-1])
     res = xr.DataArray(data=res, coords={coord: centers}, name=dat.name)


### PR DESCRIPTION
1. `util.transform.groupby_bins` can raise division by zero error when `skipna=True`, due to bins containing zero counts. Explicitly use `np.divide` to treat those cases to set the result to NaN.
2. Check whether the `filebase` keyword argument introduced in #53 is provided before retrieving its value. Otherwise it raises keyerror.